### PR TITLE
Add option to disable activating venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,6 @@ The following variables (along with their default values) control poet-v behavio
      existing ones) when entering a python window.
 - `g:poetv_statusline_symbol = ''`
     - Symbol to be displayed after venv name returned by `poetv#statusline()` function.
+- `g:poetv_set_environment = 1`
+    - If set to 1 poet-v will set the `$VIRTUAL_ENV` and `$PATH` environment variables
+      when a venv gets activated.

--- a/doc/poetv.txt
+++ b/doc/poetv.txt
@@ -45,4 +45,8 @@ g:poetv_statusline_symbol                            *g:poetv_statusline_symbol*
     Symbol to be displayed after venv name returned by `poetv#statusline()`
     function. Default: ''
 
+g:poetv_set_environment                                *g:poetv_set_environment*
+    If set to 1 poet-v will set the `$VIRTUAL_ENV` and `$PATH` environment
+    variables when a venv gets activated. Default: 1
+
 vim:tw=78:ts=8:ft=help:norl:noet:fen:

--- a/plugin/poetv.vim
+++ b/plugin/poetv.vim
@@ -24,6 +24,9 @@ endif
 if !exists('g:poetv_statusline_symbol')
     let g:poetv_statusline_symbol = ''
 endif
+if !exists('g:poetv_set_environment')
+    let g:poetv_set_environment = 1
+endif
 
 " Commands
 command! -bar PoetvActivate


### PR DESCRIPTION
This adds an option to disable setting `PATH` and `VIRTUAL_ENV`.

Not all python dependencies that I use in neovim are necessarily present in the virtual env. However, this still enables the virtual environment in deoplete-jedi and jedi-vim. And using `b:poetv_dir`, I can still easily use the detected virtual environment for other applications.