### PR TITLE
Use substitute instead of matchstr for paths with spaces

### DIFF
--- a/autoload/poetv.vim
+++ b/autoload/poetv.vim
@@ -63,7 +63,7 @@ function! poetv#activate() abort
                         break
                     endif
                 endfor
-                let poetv_out = matchstr(poetv_out, '\zs\S*')
+                let poetv_out = substitute(poetv_out, ' (Activated)$', '', '')
                 call setbufvar(curr_buffer_name, 'poetv_dir', poetv_out)
                 break
             else


### PR DESCRIPTION
Use `substitute` instead of `matchstr` to drop the ` (Activated)` suffix. Fixes #12.